### PR TITLE
fix BIG security issue

### DIFF
--- a/lib/hps/services/hps_service.rb
+++ b/lib/hps/services/hps_service.rb
@@ -62,7 +62,6 @@ module Hps
         uri = URI.parse(self.service_uri)
         http = Net::HTTP.new uri.host, uri.port
         http.use_ssl = true
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         data = xml.target!
 
         response = http.post(uri.path, data, 'Content-type' => 'text/xml')


### PR DESCRIPTION
You shouldn't set http.verify_mode = OpenSSL::SSL::VERIFY_NONE as then requests can be listened by other people by generating their own certificate. Good for developing but not more